### PR TITLE
feat: add support for opencode.jsonc config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ chmod +x opencode-dockerized.sh run-simple.sh setup.sh entrypoint.sh
 
 # Or manually create
 mkdir -p ~/.config/opencode ~/.local/share/opencode
-echo '{}' > ~/.config/opencode/opencode.json
+echo '{}' > ~/.config/opencode/opencode.json  # or opencode.jsonc
 ```
 
 ### Permission Issues with Files

--- a/opencode-dockerized.sh
+++ b/opencode-dockerized.sh
@@ -52,8 +52,8 @@ build_image() {
 check_config() {
     local missing_files=()
     
-    if [ ! -f "$HOME/.config/opencode/opencode.json" ]; then
-        missing_files+=("$HOME/.config/opencode/opencode.json")
+    if [ ! -f "$HOME/.config/opencode/opencode.json" ] && [ ! -f "$HOME/.config/opencode/opencode.jsonc" ]; then
+        missing_files+=("$HOME/.config/opencode/opencode.json (or opencode.jsonc)")
     fi
     
     if [ ! -d "$HOME/.local/share/opencode" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -24,15 +24,26 @@ ensure_dir() {
     fi
 }
 
-# Function to create file if it doesn't exist
-ensure_file() {
-    if [ ! -f "$1" ]; then
-        echo -e "${YELLOW}Creating file: $1${NC}"
-        mkdir -p "$(dirname "$1")"
-        echo "$2" > "$1"
-    else
-        echo -e "${GREEN}✓${NC} File exists: $1"
-    fi
+# Function to ensure at least one of the files exists
+# Creates the first file with default content if none exist
+ensure_any_file() {
+    local default_content="$1"
+    shift
+    local files=("$@")
+    
+    # Check if any file already exists
+    for file in "${files[@]}"; do
+        if [ -f "$file" ]; then
+            echo -e "${GREEN}✓${NC} Config file exists: $file"
+            return 0
+        fi
+    done
+    
+    # None exist, create the first one
+    local first_file="${files[0]}"
+    echo -e "${YELLOW}Creating file: $first_file${NC}"
+    mkdir -p "$(dirname "$first_file")"
+    echo "$default_content" > "$first_file"
 }
 
 echo "Checking OpenCode configuration..."
@@ -48,7 +59,7 @@ ensure_dir "$HOME/.cache/opencode"
 ensure_dir "$HOME/.mcp-auth"
 
 # Check/create OpenCode config files
-ensure_file "$HOME/.config/opencode/opencode.json" '{}'
+ensure_any_file '{}' "$HOME/.config/opencode/opencode.json" "$HOME/.config/opencode/opencode.jsonc"
 
 echo ""
 echo -e "${GREEN}Setup complete!${NC}"


### PR DESCRIPTION
## Summary
- Add support for `opencode.jsonc` as an alternative config file format
- Allows users to use JSON with comments for better documentation

## Changes
- Update config check to accept either `opencode.json` or `opencode.jsonc`
- Refactor `setup.sh` to use new `ensure_any_file()` helper function
- Update README to document the `.jsonc` option