### PR TITLE
Enabled notifications on TTYs that support escape sequences

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ FROM debian:bookworm-slim
 
 # Parameterize tool versions for easier updates
 ARG NVM_VERSION=v0.40.1
-ARG JAVA_VERSION=21.0.5-tem
+ARG JAVA_11_VERSION=11.0.25-tem
+ARG JAVA_17_VERSION=17.0.13-tem
+ARG JAVA_21_VERSION=21.0.5-tem
+ARG JAVA_25_VERSION=25.0.3-tem
 
 # Install base dependencies and useful CLI tools for coding agents
 RUN apt-get update && apt-get install -y \
@@ -48,13 +51,16 @@ RUN install -m 0755 -d /etc/apt/keyrings && \
 RUN useradd -m -s /bin/bash -u 1000 coder && \
     echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-# Install SDKMAN and Java as coder user
+# Install SDKMAN and Java LTS versions (11, 17, 21) as coder user; default is 21
 USER coder
 WORKDIR /home/coder
 RUN curl -s "https://get.sdkman.io" | bash && \
     bash -c "source /home/coder/.sdkman/bin/sdkman-init.sh && \
-    sdk install java ${JAVA_VERSION} && \
-    sdk default java ${JAVA_VERSION}"
+    sdk install java ${JAVA_11_VERSION} && \
+    sdk install java ${JAVA_17_VERSION} && \
+    sdk install java ${JAVA_21_VERSION} && \
+    sdk install java ${JAVA_25_VERSION} && \
+    sdk default java ${JAVA_21_VERSION}"
 
 # Install NVM and Node.js LTS as coder user
 ENV NVM_DIR="/home/coder/.nvm"

--- a/config-lib.sh
+++ b/config-lib.sh
@@ -215,6 +215,16 @@ build_common_docker_args() {
         -e "TERM=${TERM:-xterm-256color}"
         -e "OPENSPEC_SUPPORT=$OPENSPEC_SUPPORT"
     )
+
+    # Pass terminal identification variables so applications inside the container
+    # can detect the host terminal and use its capabilities correctly.
+    # Required for kitty OSC 99 terminal-mediated desktop notifications, true-color
+    # rendering, and other terminal-specific features. All are conditional so they
+    # have no effect on non-kitty terminals.
+    [ -n "$TERM_PROGRAM" ]         && DOCKER_COMMON_ARGS+=(-e "TERM_PROGRAM=$TERM_PROGRAM")
+    [ -n "$TERM_PROGRAM_VERSION" ] && DOCKER_COMMON_ARGS+=(-e "TERM_PROGRAM_VERSION=$TERM_PROGRAM_VERSION")
+    [ -n "$KITTY_WINDOW_ID" ]      && DOCKER_COMMON_ARGS+=(-e "KITTY_WINDOW_ID=$KITTY_WINDOW_ID")
+    [ -n "$COLORTERM" ]            && DOCKER_COMMON_ARGS+=(-e "COLORTERM=$COLORTERM")
 }
 
 # Build standard volume mount arguments for OpenCode directories

--- a/config-lib.sh
+++ b/config-lib.sh
@@ -287,6 +287,11 @@ build_standard_volume_args() {
         VOLUME_ARGS+=(-v "$HOME/.gradle/gradle.properties:/home/coder/.gradle/gradle.properties:ro")
     fi
 
+    # Git configuration (optional) — ensures commits use the host user's name and email
+    if command -v git >/dev/null 2>&1 && [ -f "$HOME/.gitconfig" ]; then
+        VOLUME_ARGS+=(-v "$HOME/.gitconfig:/home/coder/.gitconfig:ro")
+    fi
+
     # NPM configuration (optional)
     if [ -f "$HOME/.npmrc" ]; then
         VOLUME_ARGS+=(-v "$HOME/.npmrc:/home/coder/.npmrc:ro")


### PR DESCRIPTION
If there's a file `tui.json` in the ~/.config/opencode directory, containing notifications config:
```
{
	"attention": {
		"enabled": true,
		"notifications": true,
		"sound": true,
		"volume": 0.4
	}
}
```
Opencode will emit escape sequences when a question must be answered by the user, or work has been done.
This update in the config will make sure docker is started up with the correct args in the TTY to allow notifications to be passed on.
Tested with Ghostty and Kitty